### PR TITLE
feat: Add Multicast DNS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ MONITOR_WS_PORT=8001
 
 WEB_APPLICATION_HOST=localhost
 WEB_APPLICATION_PORT=8000
+# Allow reaching webplatform with any mDNS hostname
+# http://<WEB_HOSTNAME>.local:<WEB_APPLICATION_PORT>
+# => Default to http://simple.local:5173
+#WEB_HOSTNAME=simple
+
 VERBOSE=false
 
 LEARNING_PACKAGE_PATH="./learning-packages"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@homebridge/ciao": "^1.1.8",
         "@reduxjs/toolkit": "^2.2.7",
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.3",
@@ -1094,6 +1095,34 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.8.tgz",
+      "integrity": "sha512-Atn8+vwYtfI/J6nYCOVm4uVBAmiQO4rPi0umVbh766cf/OsVxQ+Qedbo9lxIf15iDsMbBlDV7T1wATdHqI5lXw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@homebridge/ciao/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3173,7 +3202,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cacheable-lookup": {
@@ -7216,7 +7244,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "fetch-scrcpy-server 3.1"
   },
   "dependencies": {
+    "@homebridge/ciao": "^1.1.8",
     "@reduxjs/toolkit": "^2.2.7",
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.3",
@@ -22,15 +23,15 @@
     "@typescript-eslint/parser": "^7.15.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@yume-chan/adb": "1.1.0",
-    "@yume-chan/fetch-scrcpy-server": "^1.0.0",
     "@yume-chan/adb-scrcpy": "1.1.0",
     "@yume-chan/adb-server-node-tcp": "1.1.0",
+    "@yume-chan/fetch-scrcpy-server": "^1.0.0",
     "@yume-chan/scrcpy-decoder-tinyh264": "1.1.0",
     "@yume-chan/scrcpy-decoder-webcodecs": "1.1.0",
     "@yume-chan/stream-extra": "^1.0.0",
     "autoprefixer": "^10.4.20",
-    "dotenv": "^16.4.5",
     "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
@@ -44,8 +45,8 @@
     "tailwindcss": "^3.4.7",
     "tsx": "^4.19.1",
     "typescript": "^5.2.2",
-    "vite": "^5.4.11",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.51.0",
+    "vite": "^5.4.11",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -5,6 +5,7 @@ import {MonitorServer} from './monitor-server.ts';
 import {AdbManager} from "./adb/AdbManager.ts";
 import {useAdb} from "./index.ts";
 import {JsonPlayerAsk, JsonOutput} from "./constants.ts";
+import {mDnsService} from "./services/mDnsService.ts";
 
 // Override the log function
 const log = (...args: any[]) => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,11 +12,12 @@ dotenv.config();
 // Default value for every option value
 process.env.GAMA_WS_PORT =                process.env.GAMA_WS_PORT                || '1000';
 process.env.GAMA_IP_ADDRESS =             process.env.GAMA_IP_ADDRESS             || 'localhost';
+process.env.WEB_APPLICATION_PORT =        process.env.WEB_APPLICATION_PORT        || '5173';
 process.env.HEADSET_WS_PORT =             process.env.HEADSET_WS_PORT             || '8080';
 process.env.MONITOR_WS_PORT =             process.env.MONITOR_WS_PORT             || '8001';
 process.env.LEARNING_PACKAGE_PATH =       process.env.LEARNING_PACKAGE_PATH       || "./learning-packages";
 process.env.EXTRA_LEARNING_PACKAGE_PATH = process.env.EXTRA_LEARNING_PACKAGE_PATH || "";
-const HEADSETS_IP: string[] = process.env.HEADSETS_IP ? process.env.HEADSETS_IP.split(';').filter((value) => value.trim() !== '') : [];
+const HEADSETS_IP: string[] =             process.env.HEADSETS_IP ? process.env.HEADSETS_IP.split(';').filter((value) => value.trim() !== '') : [];
 
 const useAggressiveDisconnect: boolean = process.env.AGGRESSIVE_DISCONNECT !== undefined ? ['true', '1', 'yes'].includes(process.env.AGGRESSIVE_DISCONNECT.toLowerCase()) : false;
 

--- a/src/api/services/mDnsService.ts
+++ b/src/api/services/mDnsService.ts
@@ -1,0 +1,45 @@
+import ciao, {Responder, ServiceType} from '@homebridge/ciao';
+import {useExtraVerbose} from "../index.ts";
+
+// Override the log function
+const log = (...args: any[]) => {
+    console.log("\x1b[37m[mDNS]\x1b[0m", ...args);
+};
+const logWarn = (...args: any[]) => {
+    console.warn("\x1b[37m[mDNS]\x1b[0m", "\x1b[43m", ...args, "\x1b[0m");
+};
+const logError = (...args: any[]) => {
+    console.error("\x1b[37m[mDNS]\x1b[0m", "\x1b[41m", ...args, "\x1b[0m");
+};
+
+export class mDnsService {
+    readonly responder: Responder;
+
+    constructor(hostname?: string) {
+        if (hostname) {
+            logWarn("You're modifying the multicast DNS hostname, this should be done only for development.");
+            logWarn("If this domain doesn't work, make sure to properly configure Vite.js to supports this domain name too.");
+        }
+
+        this.responder = ciao.getResponder();
+
+        const mDnsOptions = {
+            // @ts-ignore
+            type: ServiceType.HTTP,
+            // Ad-hoc
+            name: 'SIMPLE WebPlatform',
+            hostname: hostname ? hostname : "simple",
+            port: +process.env.WEB_APPLICATION_PORT! // `+` converts the `string` to `number`
+        };
+
+        if (useExtraVerbose) log(mDnsOptions);
+
+        this.responder.createService(mDnsOptions).advertise().then(() => {
+            log(`Application is available on http://${mDnsOptions.hostname}.local:${mDnsOptions.port} =================`);
+        });
+    }
+
+    getResponder(): Responder {
+        return this.responder;
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
     host: env.WEB_APPLICATION_HOST,
     port: Number(env.WEB_APPLICATION_PORT),
     strictPort: true,
+    allowedHosts: ["simple.local", env.WEB_HOSTNAME+".local"],
   };
 
   return {


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

## Pull Request

### Checklist
- [x] Code is complete and ready for review
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)

### Description
<!-- Briefly describe what changes were made and why. -->

Allow to not have to base all application connection with static IP address, but allow using connecting to locally exposed domain name: <host>.local
Default domain is : http://simple.local:< port>

Can be both used for Web interface and for websocket connections (monitors, websocket, unity, etc).
