### PR TITLE
[SCRCPY] Fix readFile command to properly create path for windows

### DIFF
--- a/src/api/android/scrcpy/ScrcpyServer.ts
+++ b/src/api/android/scrcpy/ScrcpyServer.ts
@@ -7,7 +7,7 @@ import { DefaultServerPath, ScrcpyMediaStreamPacket, ScrcpyCodecOptions } from "
 import {ENV_EXTRA_VERBOSE, ENV_VERBOSE, ENV_SCRCPY_FORCE_H265} from "../../index.ts";
 import { TinyH264Decoder } from "@yume-chan/scrcpy-decoder-tinyh264";
 import uWS, { TemplatedApp } from "uWebSockets.js";
-import os from "node:os";
+import path from "path";
 
 // Override the log function
 const log = (...args: any[]) => {
@@ -130,10 +130,7 @@ export class ScrcpyServer {
         // Use custom hotfix from joranmarcy
         // This fix 'simply' drop all the black frames to avoid seeing glitches on fw > 72
         // https://github.com/Genymobile/scrcpy/compare/master...joranmarcy:scrcpy:fix/opengl-discard-blackframes
-        //this.server = await fs.readFile( path.join(process.cwd(), 'toolkit', 'scrcpyServer-fixBlackClip') );
-        //const url = new URL(path.join(process.cwd(), 'toolkit', 'scrcpyServer-fixBlackClip'), import.meta.url);
-        const url = new URL(process.cwd() + '/toolkit/scrcpyServer-fixBlackClip', import.meta.url);
-        this.server = await fs.readFile(url);
+        this.server = await fs.readFile( path.join(process.cwd(), 'toolkit', 'scrcpyServer-fixBlackClip') );
     }
 
     async startStreaming(adbConnection: Adb, deviceModel: string) {


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

## Pull Request

### Checklist
- [x] Code is complete and ready for review
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)

### Description
<!-- Briefly describe what changes were made and why. -->

Scrcpy wasn't working on Windows since I migrated the project to patched scrcpy server binary.

This been fixed in this commit and tested by @tungnguyen2046 :ok_hand: 

### Related Issue
<!-- Link to any related issue (e.g., #123) if applicable. -->
