### PR TITLE
feat: add NUT (Network UPS Tools) integration base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,10 @@ LEARNING_PACKAGE_PATH="./learning-packages"
 # Default to `false`
 #AGGRESSIVE_DISCONNECT=false
 
+# -------------------------------
+# NUT (Network UPS Tools) Settings
+# -------------------------------
+# NUT_HOST=localhost
+# NUT_PORT=3493
+# NUT_UPS_NAME=myUps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "express": "^4.21.2",
         "geoip-lite": "^1.4.10",
         "i18next": "^23.15.1",
+        "nut-client": "^0.0.9",
         "postcss": "^8.4.40",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1937,9 +1938,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1952,9 +1950,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1969,9 +1964,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1984,9 +1976,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2001,9 +1990,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +2002,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2033,9 +2016,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,9 +2028,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2065,9 +2042,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2080,9 +2054,6 @@
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2097,9 +2068,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2113,9 +2081,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2128,9 +2093,6 @@
       "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9568,6 +9530,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nut-client": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/nut-client/-/nut-client-0.0.9.tgz",
+      "integrity": "sha512-5gfTTHWoSp8P7flwRU0q4osmVtyPP6BsEZZI2c0YKQa4+iI+sSyD5i2zVrfosTgkqJc5JGIdDnyYQxBJLJbMgg==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.7",
+        "tiny-typed-emitter": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/nut-client/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12298,6 +12280,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.21.2",
     "geoip-lite": "^1.4.10",
     "i18next": "^23.15.1",
+    "nut-client": "^0.0.9",
     "postcss": "^8.4.40",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/api/core/Controller.ts
+++ b/src/api/core/Controller.ts
@@ -6,6 +6,7 @@ import { AdbManager } from "../android/adb/AdbManager.ts";
 import { useAdb, ENV_GAMALESS } from "../index.ts";
 import { JsonPlayerAsk, JsonOutput } from "./Constants.ts";
 // import {mDnsService} from "../infra/mDnsService.ts";
+import { NutManager } from "../infra/nut/NutManager.ts";
 import { getLogger } from "@logtape/logtape";
 
 const logger = getLogger(["core", "Controller"]);
@@ -18,6 +19,7 @@ export class Controller {
 
     adb_manager: AdbManager | undefined;
     // mDnsService: mDnsService;
+    nut_manager: NutManager;
 
 
     constructor(useAdb: boolean) {
@@ -36,12 +38,16 @@ export class Controller {
         } else {
             logger.warn("Couldn't find ADB working or started, cancelling ADB management")
         }
+
+        this.nut_manager = new NutManager();
     }
 
     // Allow running init functions for some components needing it
     async initialize() {
         if (this.adb_manager)
             await this.adb_manager.init();
+
+        await this.nut_manager.init();
     }
 
     async restart() {
@@ -66,6 +72,9 @@ export class Controller {
         }
 
         if (useAdb) this.adb_manager = new AdbManager(this);
+
+        this.nut_manager.close();
+        this.nut_manager = new NutManager();
 
         await this.initialize();
     }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,6 +56,12 @@ process.env.EXTRA_LEARNING_PACKAGE_PATH =   process.env.EXTRA_LEARNING_PACKAGE_P
 const ENV_AGGRESSIVE_DISCONNECT: boolean = process.env.AGGRESSIVE_DISCONNECT !== undefined ? ['true', '1', 'yes'].includes(process.env.AGGRESSIVE_DISCONNECT.toLowerCase()) : false;
 // ! GAMA =====
 
+// NUT (Network UPS Tools) =====
+process.env.NUT_HOST =                      process.env.NUT_HOST                    || 'localhost';
+process.env.NUT_PORT =                      process.env.NUT_PORT                    || '3493';
+process.env.NUT_UPS_NAME =                  process.env.NUT_UPS_NAME                || 'myUps';
+// ! NUT =====
+
 // Headsets  =====
 process.env.HEADSET_WS_PORT =               process.env.HEADSET_WS_PORT             || '8080';
 // ! Headsets  =====

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -170,6 +170,7 @@ start().catch(err => {
 });
 
 export {
+    isCommandAvailable,
     ENV_GAMALESS,
     ENV_VERBOSE,
     ENV_EXTRA_VERBOSE,

--- a/src/api/infra/nut/NutManager.ts
+++ b/src/api/infra/nut/NutManager.ts
@@ -122,6 +122,24 @@ export class NutManager {
         //   - For each connected device, execute `adb shell reboot -p` to turn off the headset.
         // - Turn off the main server (Mac Mini):
         //   - Execute system `shutdown` command (e.g., `sudo shutdown -h now` on macOS/Linux).
+        //
+        // - Tell the UPS itself to turn off after a delay (e.g., 5 minutes = 300 seconds):
+        //   Example:
+        //   try {
+        //       // Ensure we're authenticated if required by your UPS setup
+        //       await this.client.connect('username', 'password');
+        //
+        //       // Try to set the shutdown delay variable (ups.delay.shutdown) to 300 seconds
+        //       await this.client.setVariable(this.upsName, 'ups.delay.shutdown', 300);
+        //
+        //       // Send the command to turn off the UPS load after the delay
+        //       await this.client.send(['INSTCMD', this.upsName, 'load.off.delay']);
+        //
+        //       logger.info(`Told UPS '${this.upsName}' to turn off its load in 5 minutes.`);
+        //   } catch (err) {
+        //       logger.error(`Failed to send shutdown command to UPS: {err}`, { err });
+        //   }
+        //
         // - Log all actions meticulously.
     }
 

--- a/src/api/infra/nut/NutManager.ts
+++ b/src/api/infra/nut/NutManager.ts
@@ -1,0 +1,136 @@
+import { NUTClient, Monitor } from 'nut-client';
+import { getLogger } from '@logtape/logtape';
+
+const logger = getLogger(["infra", "nut", "NutManager"]);
+
+export class NutManager {
+    private client: NUTClient;
+    private monitor: Monitor | null = null;
+    private upsName: string;
+
+    constructor() {
+        const host = process.env.NUT_HOST || 'localhost';
+        const port = parseInt(process.env.NUT_PORT || '3493', 10);
+        this.upsName = process.env.NUT_UPS_NAME || 'myUps';
+
+        logger.info(`Initializing NUT Manager for UPS '${this.upsName}' at ${host}:${port}`);
+
+        this.client = new NUTClient(host, port);
+    }
+
+    public async init(): Promise<void> {
+        try {
+            // First check if UPS is available
+            const upses = await this.client.listUPS();
+            logger.debug(`Available UPSes: {upses}`, {upses});
+
+            if (!upses || Object.keys(upses).length === 0) {
+                logger.warn('No UPS available or listed. Disabling NUT integration and cleaning up.');
+                this.close();
+                return;
+            }
+
+            // Check if our configured UPS is in the list
+            if (!upses[this.upsName]) {
+                logger.warn(`Configured UPS '${this.upsName}' not found in the available list. Disabling NUT integration and cleaning up.`);
+                this.close();
+                return;
+            }
+
+            // Valid UPS found. Setup Monitor
+            logger.info(`UPS '${this.upsName}' found, setting up monitor...`);
+            this.monitor = new Monitor(this.client, this.upsName);
+
+            // Setup UPS Events
+
+            // Fired when UPS switches to battery power (e.g. unplugged)
+            this.monitor.on('ONBATT', () => {
+                logger.warn(`UPS '${this.upsName}' is ON BATTERY. Power has been lost!`);
+                this.handlePowerLoss();
+            });
+
+            // Fired when UPS is back on utility power (e.g. plugged back in)
+            this.monitor.on('ONLINE', () => {
+                logger.info(`UPS '${this.upsName}' is ONLINE. Utility power has been restored!`);
+                this.handlePowerRestored();
+            });
+
+            // Fired when UPS battery is low
+            this.monitor.on('LOWBATT', () => {
+                logger.warn(`UPS '${this.upsName}' has LOW BATTERY! Preparing for shutdown sequence...`);
+                this.handleLowBattery();
+            });
+
+            // Fired when battery needs replacement
+            this.monitor.on('REPLBATT', () => {
+                logger.warn(`UPS '${this.upsName}' needs battery replacement!`);
+            });
+
+            // Fired on UPS forced shutdown (FSD)
+            this.monitor.on('FSD', () => {
+                logger.warn(`UPS '${this.upsName}' forced shutdown initiated!`);
+            });
+
+            // (Optional) Catch-all for any event or specific variable changes
+            // this.monitor.on('*', (event: string, ...args) => {
+            //     logger.trace(`UPS Event ${event}: {args}`, { args });
+            // });
+
+            await this.monitor.start();
+            logger.info('NUT Monitor started successfully.');
+
+        } catch (error) {
+            logger.error(`Failed to initialize NUT connection: {error}`, {error});
+            this.close();
+        }
+    }
+
+    private handlePowerLoss() {
+        // TODO: Handle Power Loss
+        // Possible Features:
+        // - Broadcast warning to all connected clients.
+        // - Save state of the GAMA Simulation if supported.
+        // - Consider scheduling a graceful shutdown if power isn't restored within X minutes.
+    }
+
+    private handlePowerRestored() {
+        // TODO: Handle Power Restored
+        // Possible Features:
+        // - Cancel any pending shutdowns.
+        // - Broadcast recovery message to clients.
+    }
+
+    private handleLowBattery() {
+        // TODO: Handle Low Battery Shutdown Sequence
+        // Possible Features:
+        // - Turn off VR Headsets to avoid useless battery drain:
+        //   - Retrieve `AdbManager` instance.
+        //   - For each connected device, execute `adb shell reboot -p` to turn off the headset.
+        // - Turn off the main server (Mac Mini):
+        //   - Execute system `shutdown` command (e.g., `sudo shutdown -h now` on macOS/Linux).
+        // - Log all actions meticulously.
+    }
+
+    public close() {
+        logger.debug('Cleaning up NUT Manager...');
+        if (this.monitor) {
+            try {
+                this.monitor.stop();
+            } catch (e) {
+                logger.warn('Failed to stop monitor smoothly: {e}', {e});
+            }
+            this.monitor = null;
+        }
+
+        try {
+            // We can't close client cleanly as per docs, but we can drop ref
+            // nut-client manages connections automatically
+        } catch (e) {
+            logger.trace('Error closing client {e}', {e});
+        }
+
+        this.client = null as any; // Allow GC
+    }
+}
+
+export default NutManager;

--- a/src/api/infra/nut/NutManager.ts
+++ b/src/api/infra/nut/NutManager.ts
@@ -1,5 +1,6 @@
 import { NUTClient, Monitor } from 'nut-client';
 import { getLogger } from '@logtape/logtape';
+import { isCommandAvailable } from '../../index.ts';
 
 const logger = getLogger(["infra", "nut", "NutManager"]);
 
@@ -7,19 +8,32 @@ export class NutManager {
     private client: NUTClient;
     private monitor: Monitor | null = null;
     private upsName: string;
+    private host: string;
+    private port: number;
 
     constructor() {
-        const host = process.env.NUT_HOST || 'localhost';
-        const port = parseInt(process.env.NUT_PORT || '3493', 10);
+        this.host = process.env.NUT_HOST || 'localhost';
+        this.port = parseInt(process.env.NUT_PORT || '3493', 10);
         this.upsName = process.env.NUT_UPS_NAME || 'myUps';
 
-        logger.info(`Initializing NUT Manager for UPS '${this.upsName}' at ${host}:${port}`);
+        logger.info(`Initializing NUT Manager for UPS '${this.upsName}' at ${this.host}:${this.port}`);
 
-        this.client = new NUTClient(host, port);
+        this.client = new NUTClient(this.host, this.port);
     }
 
     public async init(): Promise<void> {
         try {
+            // If connecting to localhost, check if NUT tools are installed
+            if (this.host === 'localhost' || this.host === '127.0.0.1') {
+                if (!isCommandAvailable('upsd') && !isCommandAvailable('upsc')) {
+                    logger.warn('NUT (Network UPS Tools) does not appear to be installed on this machine.');
+                    logger.warn('To use this feature on macOS, please install it via homebrew: `brew install nut`');
+                    logger.warn('Disabling NUT integration and cleaning up.');
+                    this.close();
+                    return;
+                }
+            }
+
             // First check if UPS is available
             const upses = await this.client.listUPS();
             logger.debug(`Available UPSes: {upses}`, {upses});


### PR DESCRIPTION
This PR introduces the base system for integrating UPS monitoring using Network UPS Tools (NUT). It leverages the modern `nut-client` package and its `Monitor` class to listen for UPS events such as `ONBATT`, `ONLINE`, and `LOWBATT`. 

When the Controller initializes, it will instantiate `NutManager`. The manager checks if the specified UPS is available; if not, it gracefully exits and cleans itself up. Stub functions have been added to log events and outline future implementations like executing server shutdowns or turning off connected VR headsets via ADB.


Related https://github.com/project-SIMPLE/simple.webplatform/issues/74

---
*PR created automatically by Jules for task [11356153773324197732](https://jules.google.com/task/11356153773324197732) started by @RoiArthurB*